### PR TITLE
Correct some bugs 4.1

### DIFF
--- a/classes/bulk_add_action.php
+++ b/classes/bulk_add_action.php
@@ -40,6 +40,10 @@ class bulk_add_action extends \core_question\local\bank\bulk_action_base {
         ];
     }
 
+    public function get_bulk_action_key(): string {
+        return 'move';
+    }
+    
     public function get_key(): string {
         return 'addtomoduleselected';
     }

--- a/classes/plugin_feature.php
+++ b/classes/plugin_feature.php
@@ -17,6 +17,8 @@
 namespace qbank_qtoactivity;
 
 use core_question\local\bank\plugin_features_base;
+use core_question\local\bank\bulk_action_base;
+
 
 /**
  * Adds question to activity bulk action in the bulk actions list.
@@ -34,9 +36,9 @@ class plugin_feature extends plugin_features_base {
         ];
     }
 
-    public function get_bulk_actions(): array {
-        return [
-            new bulk_add_action()
-        ];
+    public function get_bulk_actions(): ?bulk_action_base  {
+//        return [
+            return new bulk_add_action();
+//        ];
     }
 }


### PR DESCRIPTION
Hi, I think your plugin, I am forking, is one of the simplest examples of a plugin using the new API for qbank in 4.0
I am trying to write one and the first step is to turn this into a boilerplate for bulk actions on qbanks.
The final target for me are bulk actions on all question of qtype Geogebra.
You have been added as a collaborator to the fork so that you can put all the caveats for people bumping into this project when  googling for the  original one.   
When the boilerplate will be in a decent state will rename this repo. 
Boilerplate should tell how, in a plugin code,
1)-add a selection for questions / all question in a category and sub-categories
2)-add a selection for a question type
3)-display question type parameters
4)-set the given parameters on all the selected questions of the selected type.
Think that only 3 requires some ad-hoc coding so feel free to give hints for the others...
Cheers
Franco